### PR TITLE
Fix melee click input and use new tree assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
       <script src="https://cdn.babylonjs.com/babylon.js"></script>
       <script src="https://cdn.babylonjs.com/gui/babylon.gui.min.js"></script>
       <script src="https://cdn.babylonjs.com/materialsLibrary/babylonjs.materials.min.js"></script>
+      <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
    </head>
    <body>
       <!-- ========== MENU ========== -->


### PR DESCRIPTION
## Summary
- ensure the melee attack fires reliably on left clicks by handling pointer events on the canvas
- load the new FBX tree models, remove the generated grass, and reuse the imported meshes for vegetation
- extend the punch animation reach for a noticeably longer strike and add the Babylon loader script required for FBX assets

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4424d5e5083308da5512bb481a26e