### PR TITLE
Fix pause overlay resume button id

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
          <div id="pause-overlay" class="overlay">
             <div class="panel">
                <h2>Paused</h2>
-               <button id="btn-resume" class="success">Resume</button>
+               <button id="btn-resume-pause" class="success">Resume</button>
                <button id="btn-exit" class="secondary">Exit to Menu</button>
             </div>
          </div>


### PR DESCRIPTION
## Summary
- rename the pause overlay resume button to use the btn-resume-pause id expected by the game script

## Testing
- python -m http.server -d . 8080 (manual Playwright verification of pause/resume overlay)


------
https://chatgpt.com/codex/tasks/task_e_68d5a9a516cc833080b797fb61ec6faa