### PR TITLE
Add Nen aura base state toggles and HUD indicator

### DIFF
--- a/hud.js
+++ b/hud.js
@@ -6,7 +6,10 @@
     updateCooldowns: (...a)=>H.updateCooldownUI?.(...a),
     setCooldown: (...a)=>H.setCooldown?.(...a),
     isCooldown: (...a)=>H.cdActive?.(...a),
-    message: (...a)=>H.msg?.(...a)
+    message: (...a)=>H.msg?.(...a),
+    updateAuraStrip: (...a)=>H.updateAuraHud?.(...a),
+    subscribeAura: (...a)=>H.subscribeAura?.(...a),
+    getAuraState: (...a)=>H.getAuraState?.(...a)
   };
   window.HUD = HUD;
 })();

--- a/nen-core.js
+++ b/nen-core.js
@@ -4,7 +4,10 @@
   const NenCore = {
     setCooldown: (...a)=>H.setCooldown?.(...a),
     gainXP: (...a)=>H.gainXP?.(...a),
-    xpToNext: (...a)=>H.xpToNext?.(...a)
+    xpToNext: (...a)=>H.xpToNext?.(...a),
+    getAuraState: ()=>H.getAuraState?.(),
+    onAuraChange: (fn)=>H.subscribeAura?.(fn),
+    refreshAuraHud: ()=>H.updateAuraHud?.()
   };
   window.NenCore = NenCore;
 })();


### PR DESCRIPTION
## Summary
- restructure the player Nen state into structured aura and flow data with regen tracking
- add keyboard bindings for Nen disciplines and expose aura subscription helpers
- render a HUD strip showing Ten, Zetsu, Ren, Ken, Gyo, Shu, and En status in real time

## Testing
- manual: launch the game, press T/Z/K/G/B/V/R to verify HUD badges toggle and hold states update

------
https://chatgpt.com/codex/tasks/task_e_68d88f529e94833098fb3f69249e9c44