### PR TITLE
Fix Nen HUD tooltip update for jQuery wrapper

### DIFF
--- a/hud.js
+++ b/hud.js
@@ -9,7 +9,9 @@
     message: (...a)=>H.msg?.(...a),
     updateAuraStrip: (...a)=>H.updateAuraHud?.(...a),
     subscribeAura: (...a)=>H.subscribeAura?.(...a),
-    getAuraState: (...a)=>H.getAuraState?.(...a)
+    getAuraState: (...a)=>H.getAuraState?.(...a),
+    updateFlow: (...a)=>H.updateFlowHud?.(...a),
+    getFlowState: (...a)=>H.getFlowState?.(...a)
   };
   window.HUD = HUD;
 })();

--- a/nen-combat.js
+++ b/nen-combat.js
@@ -7,13 +7,39 @@ const getHXH = () => {
 };
 
 export function applyOutgoingDamage(src, limb, baseDamage) {
-  console.log("[HXH] applyOutgoingDamage", limb, baseDamage);
-  return baseDamage;
+  const H = getHXH();
+  let result = baseDamage;
+  const playerState = H.state;
+  if (src && playerState && src === playerState) {
+    const strike = playerState.koStrike;
+    if (strike) {
+      playerState.koStrike = null;
+      if (!strike.limb || strike.limb === limb) {
+        const mult = Number.isFinite(strike.multiplier) ? strike.multiplier : 1;
+        result = baseDamage * mult;
+      }
+    }
+  }
+  console.log("[HXH] applyOutgoingDamage", limb, baseDamage, "->", result);
+  return result;
 }
 
 export function applyIncomingDamage(dst, limb, baseDamage) {
-  console.log("[HXH] applyIncomingDamage", limb, baseDamage);
-  return baseDamage;
+  const H = getHXH();
+  let result = baseDamage;
+  if (dst && typeof dst === "object") {
+    const aura = dst.aura || (dst === H.state ? H.state?.aura : undefined);
+    if (aura?.ken) {
+      result *= 0.75;
+    }
+    const vulnerabilityT = Number.isFinite(dst.koVulnerabilityT) ? dst.koVulnerabilityT : 0;
+    if (vulnerabilityT > 0) {
+      const vulnMult = Number.isFinite(dst.koVulnerabilityMultiplier) ? dst.koVulnerabilityMultiplier : 1.5;
+      result *= vulnMult;
+    }
+  }
+  console.log("[HXH] applyIncomingDamage", limb, baseDamage, "->", result);
+  return result;
 }
 
 const H = getHXH();

--- a/nen-core.js
+++ b/nen-core.js
@@ -71,6 +71,8 @@
     getAuraState: ()=>H.getAuraState?.(),
     onAuraChange: (fn)=>H.subscribeAura?.(fn),
     refreshAuraHud: ()=>H.updateAuraHud?.(),
+    getFlowState: ()=>H.getFlowState?.(),
+    refreshFlowHud: ()=>H.updateFlowHud?.(),
     nenTick,
   };
   window.NenCore = NenCore;


### PR DESCRIPTION
## Summary
- add Nen flow presets, HUD visualization, and mouse-wheel cycling while Ken is held
- wire Ko strikes to consume Nen, spike outgoing damage, and trigger a vulnerability window
- pipe Ken damage reduction and Ko vulnerability multipliers through the combat hooks and expose flow helpers via HUD/Nen core
- fix the Nen HUD tooltip update so jQuery-wrapped elements use attr when available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d97139bd2083309eed353c8d4960d9