### PR TITLE
Simplify inventory system with durability hooks

### DIFF
--- a/hud.js
+++ b/hud.js
@@ -4,6 +4,190 @@
   const ensureHudRoot = () => document.getElementById("hud");
   const ensureHead = () => document.head || document.getElementsByTagName("head")[0] || null;
 
+  const HOTBAR_SIZE = 9;
+  let hotbarCache = null;
+
+  function formatItemLabel(item) {
+    if (!item) return "";
+    if (typeof item.name === "string" && item.name.trim()) return item.name.trim();
+    if (typeof item.label === "string" && item.label.trim()) return item.label.trim();
+    const id = typeof item.id === "string" ? item.id : "";
+    if (!id) return "";
+    return id
+      .split(/[-_\s]+/)
+      .filter(Boolean)
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+  }
+
+  function ensureHotbar() {
+    const root = ensureHudRoot();
+    if (!root) return null;
+    const bottom = document.getElementById("hud-bottom");
+    if (!bottom) return null;
+    if (hotbarCache && hotbarCache.root && bottom.contains(hotbarCache.root)) {
+      return hotbarCache;
+    }
+
+    let container = bottom.querySelector("#hud-hotbar");
+    if (!container) {
+      container = document.createElement("div");
+      container.id = "hud-hotbar";
+      bottom.appendChild(container);
+    } else {
+      container.innerHTML = "";
+    }
+
+    container.classList.add("hud-hotbar");
+    container.style.display = "grid";
+    container.style.gridTemplateColumns = "repeat(9, minmax(0, 1fr))";
+    container.style.gap = "0.35rem";
+    container.style.marginTop = "0.75rem";
+    container.style.pointerEvents = "auto";
+    container.style.userSelect = "none";
+
+    const slots = new Array(HOTBAR_SIZE);
+    for (let i = 0; i < HOTBAR_SIZE; i += 1) {
+      const slot = document.createElement("button");
+      slot.type = "button";
+      slot.dataset.index = String(i);
+      slot.className = "hud-hotbar-slot";
+      slot.style.display = "flex";
+      slot.style.flexDirection = "column";
+      slot.style.alignItems = "stretch";
+      slot.style.justifyContent = "space-between";
+      slot.style.padding = "0.35rem 0.4rem";
+      slot.style.borderRadius = "8px";
+      slot.style.background = "rgba(16, 24, 36, 0.55)";
+      slot.style.border = "1px solid rgba(255,255,255,0.1)";
+      slot.style.color = "#f5faff";
+      slot.style.fontSize = "0.7rem";
+      slot.style.textAlign = "left";
+      slot.style.cursor = "pointer";
+      slot.style.transition = "background-color 0.15s ease, border-color 0.18s ease, transform 0.12s ease";
+      slot.style.position = "relative";
+      slot.style.minHeight = "3.1rem";
+      slot.style.pointerEvents = "auto";
+
+      const key = document.createElement("span");
+      key.dataset.role = "key";
+      key.textContent = String(i + 1);
+      key.style.fontSize = "0.65rem";
+      key.style.opacity = "0.6";
+      key.style.alignSelf = "flex-end";
+
+      const label = document.createElement("span");
+      label.dataset.role = "label";
+      label.style.fontSize = "0.78rem";
+      label.style.fontWeight = "600";
+      label.style.whiteSpace = "nowrap";
+      label.style.overflow = "hidden";
+      label.style.textOverflow = "ellipsis";
+
+      const info = document.createElement("div");
+      info.style.display = "flex";
+      info.style.alignItems = "center";
+      info.style.justifyContent = "space-between";
+      info.style.gap = "0.35rem";
+      info.style.marginTop = "0.25rem";
+      info.style.fontSize = "0.65rem";
+
+      const stack = document.createElement("span");
+      stack.dataset.role = "stack";
+      stack.style.opacity = "0.75";
+      stack.style.minWidth = "2.4ch";
+
+      const durWrap = document.createElement("div");
+      durWrap.dataset.role = "dur-wrap";
+      durWrap.style.flex = "1";
+      durWrap.style.height = "4px";
+      durWrap.style.background = "rgba(255,255,255,0.18)";
+      durWrap.style.borderRadius = "4px";
+      durWrap.style.overflow = "hidden";
+
+      const dur = document.createElement("div");
+      dur.dataset.role = "dur";
+      dur.style.height = "100%";
+      dur.style.width = "0%";
+      dur.style.background = "linear-gradient(90deg, #4cd5ff, #5effc8)";
+      dur.style.transition = "width 0.12s ease";
+
+      durWrap.appendChild(dur);
+      info.appendChild(stack);
+      info.appendChild(durWrap);
+
+      slot.appendChild(key);
+      slot.appendChild(label);
+      slot.appendChild(info);
+
+      container.appendChild(slot);
+      slots[i] = { root: slot, labelEl: label, stackEl: stack, durEl: dur, durWrap };
+    }
+
+    hotbarCache = { root: container, slots };
+    return hotbarCache;
+  }
+
+  function renderHotbar(inventory) {
+    const cache = ensureHotbar();
+    if (!cache) return;
+    const slots = cache.slots;
+    for (let i = 0; i < slots.length; i += 1) {
+      const slotMeta = slots[i];
+      if (!slotMeta) continue;
+      const slotIndex = inventory && Array.isArray(inventory.hotbar) ? inventory.hotbar[i] : null;
+      const item = typeof slotIndex === "number" && inventory?.slots ? inventory.slots[slotIndex] : null;
+      const active = inventory?.activeHotbar === i && item && !item.broken;
+      slotMeta.root.classList.toggle("active", !!active);
+      slotMeta.root.classList.toggle("empty", !item);
+      slotMeta.root.classList.toggle("broken", !!item && !!item.broken);
+      slotMeta.root.style.background = active ? "rgba(38, 72, 112, 0.65)" : "rgba(16, 24, 36, 0.55)";
+      slotMeta.root.style.borderColor = active ? "rgba(86, 214, 255, 0.95)" : item ? "rgba(255,255,255,0.16)" : "rgba(255,255,255,0.08)";
+      slotMeta.root.style.transform = active ? "translateY(-2px)" : "translateY(0)";
+
+      slotMeta.labelEl.textContent = item ? formatItemLabel(item) : "";
+      const stackInfo = item && item.stack && item.stack.max > 1
+        ? `${Math.max(0, item.stack.count ?? 0)}/${Math.max(1, item.stack.max ?? 1)}`
+        : "";
+      slotMeta.stackEl.textContent = stackInfo;
+      slotMeta.stackEl.style.visibility = stackInfo ? "visible" : "hidden";
+
+      if (item && item.dur && item.dur.max > 0) {
+        const ratio = Math.max(0, Math.min(1, item.dur.current / Math.max(1, item.dur.max)));
+        slotMeta.durEl.style.width = `${ratio * 100}%`;
+        slotMeta.durWrap.style.opacity = "1";
+      } else {
+        slotMeta.durEl.style.width = "0%";
+        slotMeta.durWrap.style.opacity = item ? "0.35" : "0.12";
+      }
+    }
+  }
+
+  function flashHotbar(index) {
+    const cache = hotbarCache || ensureHotbar();
+    if (!cache) return;
+    const slot = cache.slots[index];
+    if (!slot) return;
+    slot.root.style.boxShadow = "0 0 12px rgba(255,82,82,0.75)";
+    setTimeout(() => {
+      slot.root.style.boxShadow = "";
+    }, 220);
+  }
+
+  function bindHotbar(handler) {
+    const cache = ensureHotbar();
+    if (!cache) return () => {};
+    const listener = (event) => {
+      const target = event.target instanceof Element ? event.target.closest(".hud-hotbar-slot") : null;
+      if (!target) return;
+      const index = Number.parseInt(target.dataset.index ?? "", 10);
+      if (!Number.isInteger(index)) return;
+      handler?.(index, event);
+    };
+    cache.root.addEventListener("click", listener);
+    return () => cache.root.removeEventListener("click", listener);
+  }
+
   const HUD = {
     update: (...a)=>H.updateHUD?.(...a),
     updateCooldowns: (...a)=>H.updateCooldownUI?.(...a),
@@ -43,7 +227,11 @@
       style.textContent = css;
       head.appendChild(style);
       return style;
-    }
+    },
+    ensureHotbar,
+    renderHotbar,
+    bindHotbar,
+    flashHotbarBreak: flashHotbar
   };
   window.HUD = HUD;
 })();

--- a/items-and-crafting.js
+++ b/items-and-crafting.js
@@ -1,165 +1,345 @@
-// items-and-crafting.js — lightweight item helpers + Shu runtime metadata
+// items-and-crafting.js — inventory + durability helpers
 (function(){
   const globalObj = typeof window !== "undefined" ? window : globalThis;
-  const existing = typeof globalObj.Items === "object" && globalObj.Items ? globalObj.Items : {};
-  if (!existing.recipes) existing.recipes = {};
-  if (typeof existing.craft !== "function") existing.craft = function(){ return false; };
+  const Items = globalObj.Items = globalObj.Items || {};
 
-  const Items = globalObj.Items = existing;
   const runtime = Items.__runtime = Items.__runtime || {};
-  const supportsWeakMap = typeof WeakMap === "function";
 
-  const DEFAULT_SHU = { damageMul: 1.3, durabilityScalar: 0.65, pierceCount: 1 };
-  const DEFAULT_WEAPON_HUD_SELECTORS = [
-    '[data-slot="weapon"].active',
-    '#hud-weapon-active',
-    '#hud-weapon',
-    '.hud-weapon.active',
-    '.hud-hotbar .slot[data-slot="weapon"].active'
-  ];
+  const ItemSchema = Items.ItemSchema = Object.freeze({
+    id: { required: true },
+    slot: { default: "inventory" },
+    type: { default: "generic" },
+    dmg: { default: 0 },
+    dur: { default: () => ({ current: 0, max: 0 }) },
+    tags: { default: () => [] },
+    stack: { default: () => ({ count: 1, max: 1 }) }
+  });
+
+  const HOTBAR_SIZE = 9;
+  const DEFAULT_SHU = { damageMul: 1, durabilityScalar: 1, pierceCount: 0 };
+  const DEFAULT_WEAPON_HUD_SELECTORS = ["[data-weapon]", "#hud-weapon"];
+  const listeners = new Set();
+  const slots = [];
+  const hotbar = new Array(HOTBAR_SIZE).fill(null);
+
+  let activeHotbar = null;
+  let activeItem = null;
+  let ownerState = null;
+  let pendingAttack = null;
+
+  const supportsWeakSet = typeof WeakSet === "function";
   if (!runtime.shuDefaults) runtime.shuDefaults = { ...DEFAULT_SHU };
-  runtime.shu = runtime.shu || null;
-  if (!runtime.lastWeaponByOwner) {
-    runtime.lastWeaponByOwner = supportsWeakMap ? new WeakMap() : [];
+  if (!Array.isArray(runtime.weaponHudSelectors) || runtime.weaponHudSelectors.length === 0) {
+    runtime.weaponHudSelectors = DEFAULT_WEAPON_HUD_SELECTORS.slice();
   }
-  runtime.weaponHudSelectors = Array.isArray(runtime.weaponHudSelectors)
-    ? runtime.weaponHudSelectors.slice()
-    : [...DEFAULT_WEAPON_HUD_SELECTORS];
+  let weaponHudSelectors = runtime.weaponHudSelectors.slice();
+  Items.weaponHudSelectors = weaponHudSelectors.slice();
+  let shuDefaults = { ...runtime.shuDefaults };
+  runtime.shuDefaults = { ...shuDefaults };
+  let recordedShu = runtime.shu ? { ...runtime.shu } : null;
 
-  function toFinite(value) {
-    if (typeof value === "number" && Number.isFinite(value)) return value;
-    if (typeof value === "string" && value.trim() !== "") {
-      const parsed = Number.parseFloat(value);
-      if (Number.isFinite(parsed)) return parsed;
+  function emit(change) {
+    listeners.forEach((fn) => {
+      try {
+        fn(change, inventory);
+      } catch (err) {
+        console.warn("[HXH] inventory listener failed", err);
+      }
+    });
+  }
+
+  function toNumber(value, fallback = 0) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : fallback;
+  }
+
+  function ensureString(value, fallback = "") {
+    if (typeof value === "string" && value.trim()) return value.trim();
+    if (Number.isFinite(value)) return String(value);
+    return fallback;
+  }
+
+  function normalizeDurability(value) {
+    if (value && typeof value === "object") {
+      const max = Math.max(0, toNumber(value.max ?? value.maximum ?? value.cap, 0));
+      const current = Math.min(max, Math.max(0, toNumber(value.current ?? value.cur ?? value.value, max)));
+      return { current, max };
+    }
+    if (Number.isFinite(value) && value >= 0) {
+      const safe = Math.floor(value);
+      return { current: safe, max: safe };
+    }
+    return { current: 0, max: 0 };
+  }
+
+  function normalizeStack(value) {
+    if (value && typeof value === "object") {
+      const max = Math.max(1, Math.floor(toNumber(value.max ?? value.limit ?? value.size, 1)));
+      const count = Math.max(0, Math.min(max, Math.floor(toNumber(value.count ?? value.cur ?? value.quantity, 1))));
+      return { count, max };
+    }
+    if (Number.isFinite(value) && value > 0) {
+      const qty = Math.floor(value);
+      return { count: qty, max: qty };
+    }
+    return { count: 1, max: 1 };
+  }
+
+  function createItem(data = {}) {
+    const id = ensureString(data.id, `item-${Date.now().toString(16)}-${Math.random().toString(16).slice(2)}`);
+    const slot = ensureString(data.slot, ItemSchema.slot.default).toLowerCase();
+    const type = ensureString(data.type, slot === "weapon" ? "weapon" : ItemSchema.type.default).toLowerCase();
+    const dmg = toNumber(data.dmg, ItemSchema.dmg.default);
+    const dur = normalizeDurability(data.dur);
+    const tags = Array.isArray(data.tags) ? data.tags.filter(tag => typeof tag === "string" && tag.trim()).map(tag => tag.trim()) : [];
+    const stack = normalizeStack(data.stack);
+    const item = {
+      id,
+      slot,
+      type,
+      dmg,
+      dur,
+      tags,
+      stack,
+      broken: dur.current <= 0
+    };
+    Object.defineProperty(item, "__slotIndex", { value: -1, writable: true, configurable: true });
+    return item;
+  }
+
+  function cloneItem(item) {
+    if (!item || typeof item !== "object") return null;
+    const copy = createItem(item);
+    copy.dur = { current: item.dur?.current ?? 0, max: item.dur?.max ?? 0 };
+    copy.stack = { count: item.stack?.count ?? 1, max: item.stack?.max ?? 1 };
+    copy.broken = !!item.broken;
+    return copy;
+  }
+
+  function updateActive(newHotbar, newItem) {
+    activeHotbar = newHotbar;
+    activeItem = newItem && !newItem.broken ? newItem : null;
+    inventory.activeHotbar = activeHotbar;
+    inventory.activeItem = activeItem;
+    if (ownerState && typeof ownerState === "object") {
+      ownerState.weapon = activeItem || null;
+    }
+    runtime.activeHotbar = activeHotbar;
+    runtime.activeItem = activeItem;
+  }
+
+  function normalizeHotbarIndex(index) {
+    if (!Number.isInteger(index)) return null;
+    if (index < 0 || index >= HOTBAR_SIZE) return null;
+    return index;
+  }
+
+  function findHotbarIndexForSlot(slotIndex) {
+    for (let i = 0; i < hotbar.length; i += 1) {
+      if (hotbar[i] === slotIndex) return i;
     }
     return null;
   }
 
-  function clampPositive(value, fallback) {
-    const finite = toFinite(value);
-    if (finite === null) return fallback;
-    return finite > 0 ? finite : fallback;
-  }
-
-  function detectWeaponFromSlots(slots) {
-    if (!Array.isArray(slots)) return null;
-    for (const slot of slots) {
-      if (!slot || typeof slot !== "object") continue;
-      const slotName = typeof slot.slot === "string" ? slot.slot : slot.name;
-      if (slotName && slotName.toLowerCase() === "weapon" && slot.item) {
-        return slot.item;
+  function assignHotbar(slotIndex, preferredIndex = null) {
+    const target = normalizeHotbarIndex(preferredIndex);
+    if (target !== null) {
+      for (let i = 0; i < hotbar.length; i += 1) {
+        if (hotbar[i] === slotIndex) hotbar[i] = null;
+      }
+      hotbar[target] = slotIndex;
+      return target;
+    }
+    for (let i = 0; i < hotbar.length; i += 1) {
+      if (hotbar[i] === null || typeof hotbar[i] === "undefined") {
+        hotbar[i] = slotIndex;
+        return i;
       }
     }
     return null;
   }
 
-  function rememberWeapon(state, weapon) {
-    if (!weapon || typeof weapon !== "object") return null;
-    runtime.lastWeapon = weapon;
-    if (state && typeof state === "object") {
-      const store = runtime.lastWeaponByOwner;
-      if (store instanceof WeakMap) {
-        store.set(state, weapon);
-      } else if (Array.isArray(store)) {
-        let updated = false;
-        for (let i = 0; i < store.length; i += 1) {
-          const entry = store[i];
-          if (entry && entry.owner === state) {
-            store[i] = { owner: state, item: weapon };
-            updated = true;
-            break;
-          }
-        }
-        if (!updated) store.push({ owner: state, item: weapon });
+  function clearHotbarSlot(slotIndex) {
+    const cleared = [];
+    for (let i = 0; i < hotbar.length; i += 1) {
+      if (hotbar[i] === slotIndex) {
+        hotbar[i] = null;
+        cleared.push(i);
       }
-      runtime.activeWeapon = { owner: state, item: weapon };
     }
-    return weapon;
+    return cleared;
   }
 
-  function forgetWeapon(state) {
-    if (!state || typeof state !== "object") return;
-    const store = runtime.lastWeaponByOwner;
-    if (runtime.activeWeapon && runtime.activeWeapon.owner === state) {
-      runtime.activeWeapon = null;
-    }
-    if (store instanceof WeakMap) {
-      store.delete(state);
-    } else if (Array.isArray(store)) {
-      for (let i = store.length - 1; i >= 0; i -= 1) {
-        const entry = store[i];
-        if (entry && entry.owner === state) {
-          store.splice(i, 1);
-        }
-      }
+  function setSlot(slotIndex, item) {
+    if (slotIndex < 0) return;
+    while (slotIndex >= slots.length) slots.push(null);
+    slots[slotIndex] = item;
+    if (item) {
+      item.__slotIndex = slotIndex;
+      item.broken = item.dur.current <= 0;
     }
   }
 
-  function detectActiveWeapon(state) {
-    if (!state || typeof state !== "object") return null;
-    if (state.weapon && typeof state.weapon === "object") {
-      return rememberWeapon(state, state.weapon);
+  function findEmptySlot() {
+    for (let i = 0; i < slots.length; i += 1) {
+      if (!slots[i]) return i;
     }
-    const eq = state.equipment;
-    if (eq && typeof eq === "object") {
-      if (typeof eq.getActiveWeapon === "function") {
-        try {
-          const weapon = eq.getActiveWeapon();
-          if (weapon) return rememberWeapon(state, weapon);
-        } catch (err) {
-          console.warn("[HXH] Items.getActiveWeapon failed", err);
-        }
-      }
-      if (eq.activeWeapon && typeof eq.activeWeapon === "object") {
-        return rememberWeapon(state, eq.activeWeapon);
-      }
-      if (eq.weapon && typeof eq.weapon === "object") {
-        return rememberWeapon(state, eq.weapon);
-      }
-      if (eq.active && typeof eq.active === "object") {
-        const slot = eq.active;
-        const slotName = typeof slot.slot === "string" ? slot.slot : slot.type;
-        if (slotName && slotName.toLowerCase() === "weapon") {
-          const weapon = slot.item || slot;
-          if (weapon && typeof weapon === "object") return rememberWeapon(state, weapon);
-        }
-      }
-      const slotWeapon = detectWeaponFromSlots(eq.slots);
-      if (slotWeapon) return rememberWeapon(state, slotWeapon);
-    }
-    if (state.activeItem && typeof state.activeItem === "object") {
-      const slot = state.activeItem;
-      const slotName = typeof slot.slot === "string" ? slot.slot : slot.type;
-      if (slotName && slotName.toLowerCase() === "weapon") {
-        const weapon = slot.item || slot;
-        if (weapon && typeof weapon === "object") return rememberWeapon(state, weapon);
-      }
-    }
-    forgetWeapon(state);
-    return null;
+    return slots.length;
   }
 
-  function isWeaponOut(state, weapon = detectActiveWeapon(state)) {
-    if (!weapon || typeof weapon !== "object") return false;
-    if (weapon.disabled || weapon.broken) return false;
-    if ("out" in weapon) return !!weapon.out;
-    if ("drawn" in weapon) return !!weapon.drawn;
-    if ("equipped" in weapon) return !!weapon.equipped;
-    if ("active" in weapon) return !!weapon.active;
-    if ("holstered" in weapon) return !weapon.holstered;
-    if (state && typeof state === "object") {
-      const combat = state.combat;
-      if (combat && typeof combat === "object" && "weaponOut" in combat) {
-        return !!combat.weaponOut;
-      }
+  function serializeItem(item) {
+    if (!item) return null;
+    return {
+      id: item.id,
+      slot: item.slot,
+      type: item.type,
+      dmg: item.dmg,
+      dur: { current: item.dur?.current ?? 0, max: item.dur?.max ?? 0 },
+      tags: Array.isArray(item.tags) ? item.tags.slice() : [],
+      stack: { count: item.stack?.count ?? 1, max: item.stack?.max ?? 1 },
+      broken: !!item.broken
+    };
+  }
+
+  function markHit(pending, dst) {
+    if (!pending) return false;
+    if (!dst || typeof dst !== "object") return true;
+    if (supportsWeakSet) {
+      if (!pending.hitSet) pending.hitSet = new WeakSet();
+      if (pending.hitSet.has(dst)) return false;
+      pending.hitSet.add(dst);
+      return true;
     }
-    if (runtime.shu && runtime.shu.weapon === weapon && "weaponOut" in runtime.shu) {
-      return !!runtime.shu.weaponOut;
-    }
+    if (!Array.isArray(pending.hitList)) pending.hitList = [];
+    if (pending.hitList.includes(dst)) return false;
+    pending.hitList.push(dst);
     return true;
   }
 
-  function getShuConfig(weapon) {
+  function breakItem(item, reason = "durability") {
+    if (!item) return;
+    const slotIndex = Number.isInteger(item.__slotIndex) ? item.__slotIndex : slots.indexOf(item);
+    const hotbarCleared = slotIndex >= 0 ? clearHotbarSlot(slotIndex) : [];
+    if (slotIndex >= 0 && slots[slotIndex] === item) {
+      slots[slotIndex] = null;
+    }
+    if (activeHotbar !== null && (hotbar[activeHotbar] === slotIndex || activeItem === item)) {
+      updateActive(null, null);
+    }
+    item.broken = true;
+    if (item.dur) item.dur.current = 0;
+    emit({ type: "break", slotIndex, hotbarIndices: hotbarCleared, item, reason });
+  }
+
+  function damageItem(item, amount = 1) {
+    if (!item || !item.dur) return 0;
+    const cost = Math.max(0, toNumber(amount, 0));
+    if (cost <= 0) return item.dur.current ?? 0;
+    const slotIndex = Number.isInteger(item.__slotIndex) ? item.__slotIndex : slots.indexOf(item);
+    item.dur.current = Math.max(0, Math.min(item.dur.max, toNumber(item.dur.current, 0) - cost));
+    if (item.dur.current <= 0) {
+      item.broken = true;
+      emit({ type: "durability", slotIndex, item });
+      breakItem(item, "durability");
+      return 0;
+    }
+    item.broken = false;
+    emit({ type: "durability", slotIndex, item });
+    return item.dur.current;
+  }
+
+  const inventory = {
+    slots,
+    hotbar,
+    activeHotbar: activeHotbar,
+    activeItem: activeItem,
+    add(rawItem, options = {}) {
+      const item = rawItem && typeof rawItem === "object" && rawItem.id ? cloneItem(rawItem) : createItem(rawItem);
+
+      if (item.stack.max > 1) {
+        for (let i = 0; i < slots.length && item.stack.count > 0; i += 1) {
+          const existing = slots[i];
+          if (!existing || existing.id !== item.id || existing.stack.max <= existing.stack.count) continue;
+          const space = existing.stack.max - existing.stack.count;
+          const transfer = Math.min(space, item.stack.count);
+          if (transfer > 0) {
+            existing.stack.count += transfer;
+            item.stack.count -= transfer;
+            emit({ type: "stack", slotIndex: i, item: existing, transfer });
+          }
+        }
+        if (item.stack.count <= 0) {
+          return null;
+        }
+      }
+
+      const slotIndex = Number.isInteger(options.slotIndex) ? Math.max(0, options.slotIndex) : findEmptySlot();
+      setSlot(slotIndex, item);
+      const assignedHotbar = assignHotbar(slotIndex, options.hotbarIndex);
+      emit({ type: "add", slotIndex, hotbarIndex: assignedHotbar, item });
+
+      const shouldEquip = options.autoEquip ?? (item.slot === "weapon" && assignedHotbar !== null && !inventory.activeItem);
+      if (shouldEquip && assignedHotbar !== null) {
+        inventory.equip(assignedHotbar, { silent: true });
+      }
+      return { item, slotIndex, hotbarIndex: assignedHotbar };
+    },
+    use(index, options = {}) {
+      return this.equip(index, options);
+    },
+    equip(index, options = {}) {
+      const hotbarIndex = normalizeHotbarIndex(index);
+      if (hotbarIndex === null) {
+        if (inventory.activeHotbar !== null) {
+          updateActive(null, null);
+          if (!options.silent) emit({ type: "equip", hotbarIndex: null, slotIndex: null, item: null });
+        }
+        return null;
+      }
+      const slotIndex = hotbar[hotbarIndex];
+      const item = Number.isInteger(slotIndex) ? slots[slotIndex] : null;
+      if (!item || item.broken) {
+        if (item && item.broken) breakItem(item, "broken-equip");
+        if (inventory.activeHotbar === hotbarIndex) {
+          updateActive(null, null);
+        }
+        if (!options.silent) emit({ type: "equip", hotbarIndex, slotIndex, item: null });
+        return null;
+      }
+      updateActive(hotbarIndex, item);
+      if (!options.silent) emit({ type: "equip", hotbarIndex, slotIndex, item });
+      return item;
+    },
+    subscribe(fn) {
+      if (typeof fn !== "function") return () => {};
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    },
+    toJSON() {
+      return {
+        slots: slots.map(serializeItem),
+        hotbar: hotbar.slice(),
+        activeHotbar: activeHotbar
+      };
+    }
+  };
+
+  Items.createItem = createItem;
+  Items.cloneItem = cloneItem;
+  Items.inventory = inventory;
+  runtime.inventory = inventory;
+  Items.getActiveItem = () => activeItem && !activeItem.broken ? activeItem : null;
+  Items.damageItem = damageItem;
+  Items.breakItem = breakItem;
+  Items.bindPlayerState = function(state) {
+    ownerState = state || null;
+    runtime.playerState = ownerState;
+    runtime.inventory = inventory;
+    updateActive(activeHotbar, activeItem);
+    return inventory;
+  };
+
+  function computeWeaponConfig(weapon) {
     if (!weapon || typeof weapon !== "object") return null;
     if (weapon.shu && typeof weapon.shu === "object") return weapon.shu;
     if (weapon.nen && typeof weapon.nen === "object" && weapon.nen.shu && typeof weapon.nen.shu === "object") {
@@ -174,99 +354,87 @@
     return null;
   }
 
-  function computeShuModifiers(state, weapon = detectActiveWeapon(state)) {
-    const defaults = runtime.shuDefaults || DEFAULT_SHU;
-    const result = {
-      damageMul: defaults.damageMul,
-      durabilityScalar: defaults.durabilityScalar,
-      pierceCount: defaults.pierceCount
-    };
-
-    const config = getShuConfig(weapon);
+  function computeShuModifiers(state, weapon = Items.getActiveItem() || (state && state.weapon) || null) {
+    const result = { ...shuDefaults };
+    const config = computeWeaponConfig(weapon);
     if (config) {
-      const dmg = toFinite(config.damageMul ?? config.damageMultiplier ?? config.damage ?? config.power);
-      if (dmg !== null) result.damageMul = dmg;
-      const dura = toFinite(config.durabilityScalar ?? config.durabilityMultiplier ?? config.durabilityEfficiency);
-      if (dura !== null) result.durabilityScalar = dura;
-      const pierce = toFinite(config.pierceCount ?? config.pierce ?? config.pierceBonus);
-      if (pierce !== null) result.pierceCount = pierce;
+      const dmg = toNumber(config.damageMul ?? config.damageMultiplier ?? config.damage ?? config.power, result.damageMul);
+      if (dmg > 0) result.damageMul = dmg;
+      const dur = toNumber(config.durabilityScalar ?? config.durabilityMultiplier ?? config.durabilityEfficiency, result.durabilityScalar);
+      if (dur > 0) result.durabilityScalar = dur;
+      const pierce = toNumber(config.pierceCount ?? config.pierce ?? config.pierceBonus, result.pierceCount);
+      if (pierce >= 0) result.pierceCount = pierce;
     }
-
     if (weapon && typeof weapon === "object") {
-      const directDmg = toFinite(weapon.shuDamageMul ?? weapon.shuDamageMultiplier ?? weapon.shuDamage);
-      if (directDmg !== null) result.damageMul = directDmg;
-      const directDur = toFinite(weapon.shuDurabilityScalar ?? weapon.shuDurabilityMultiplier ?? weapon.shuDurabilityEfficiency);
-      if (directDur !== null) result.durabilityScalar = directDur;
-      const directPierce = toFinite(weapon.shuPierceCount ?? weapon.shuPierce ?? weapon.shuPierceBonus);
-      if (directPierce !== null) result.pierceCount = directPierce;
+      const directDmg = toNumber(weapon.shuDamageMul ?? weapon.shuDamageMultiplier ?? weapon.shuDamage, result.damageMul);
+      if (directDmg > 0) result.damageMul = directDmg;
+      const directDur = toNumber(weapon.shuDurabilityScalar ?? weapon.shuDurabilityMultiplier ?? weapon.shuDurabilityEfficiency, result.durabilityScalar);
+      if (directDur > 0) result.durabilityScalar = directDur;
+      const directPierce = toNumber(weapon.shuPierceCount ?? weapon.shuPierce ?? weapon.shuPierceBonus, result.pierceCount);
+      if (directPierce >= 0) result.pierceCount = directPierce;
     }
-
-    result.damageMul = clampPositive(result.damageMul, defaults.damageMul);
-    result.durabilityScalar = clampPositive(result.durabilityScalar, defaults.durabilityScalar);
-    const pierceSafe = toFinite(result.pierceCount);
-    result.pierceCount = pierceSafe !== null && pierceSafe >= 0 ? pierceSafe : defaults.pierceCount;
-
     result.damageMultiplier = result.damageMul;
     result.durabilityMultiplier = result.durabilityScalar;
     result.pierce = result.pierceCount;
     return result;
   }
 
-  function applyShuDurabilityCost(baseCost, state, weapon = detectActiveWeapon(state)) {
-    const cost = toFinite(baseCost);
-    if (cost === null) return 0;
+  function applyShuDurabilityCost(baseCost, state, weapon = Items.getActiveItem() || (state && state.weapon) || null) {
+    const cost = Math.max(0, toNumber(baseCost, 0));
+    if (cost <= 0) return 0;
     const mods = computeShuModifiers(state, weapon);
-    const scalar = typeof mods.durabilityScalar === "number" && Number.isFinite(mods.durabilityScalar)
-      ? mods.durabilityScalar
-      : 1;
-    return Math.max(0, cost * scalar);
+    const scalar = Number.isFinite(mods.durabilityScalar) && mods.durabilityScalar > 0 ? mods.durabilityScalar : 1;
+    return cost * scalar;
+  }
+
+  function setShuDefaults(config = {}) {
+    const damage = toNumber(config.damageMul ?? config.damageMultiplier, shuDefaults.damageMul);
+    const durability = toNumber(config.durabilityScalar ?? config.durabilityMultiplier ?? config.durabilityEfficiency, shuDefaults.durabilityScalar);
+    const pierce = toNumber(config.pierceCount ?? config.pierce ?? config.pierceBonus, shuDefaults.pierceCount);
+    shuDefaults = {
+      damageMul: damage > 0 ? damage : DEFAULT_SHU.damageMul,
+      durabilityScalar: durability > 0 ? durability : DEFAULT_SHU.durabilityScalar,
+      pierceCount: pierce >= 0 ? pierce : DEFAULT_SHU.pierceCount
+    };
+    runtime.shuDefaults = { ...shuDefaults };
+    Items.shuDefaults = { ...shuDefaults };
+    return { ...shuDefaults };
   }
 
   function recordShuState(info) {
     if (!info) {
+      recordedShu = null;
       runtime.shu = null;
       return null;
     }
-    runtime.shu = {
+    recordedShu = {
       intent: !!info.intent,
       active: !!info.active,
       weaponOut: !!info.weaponOut,
-      weapon: info.weapon || null,
+      weapon: info.weapon || Items.getActiveItem() || null,
       modifiers: info.modifiers ? { ...info.modifiers } : null
     };
-    if (info.weapon && typeof info.weapon === "object") {
-      runtime.lastWeapon = info.weapon;
+    runtime.shu = { ...recordedShu };
+    if (recordedShu.weapon) {
+      runtime.lastWeapon = recordedShu.weapon;
     }
-    return runtime.shu;
+    return { ...recordedShu };
   }
 
   function getRecordedShuState() {
-    if (!runtime.shu) return null;
+    if (!recordedShu) return null;
     return {
-      intent: !!runtime.shu.intent,
-      active: !!runtime.shu.active,
-      weaponOut: !!runtime.shu.weaponOut,
-      weapon: runtime.shu.weapon || null,
-      modifiers: runtime.shu.modifiers ? { ...runtime.shu.modifiers } : null
+      intent: recordedShu.intent,
+      active: recordedShu.active,
+      weaponOut: recordedShu.weaponOut,
+      weapon: recordedShu.weapon || null,
+      modifiers: recordedShu.modifiers ? { ...recordedShu.modifiers } : null
     };
-  }
-
-  function setShuDefaults(config = {}) {
-    runtime.shuDefaults = {
-      damageMul: clampPositive(config.damageMul ?? config.damageMultiplier, DEFAULT_SHU.damageMul),
-      durabilityScalar: clampPositive(config.durabilityScalar ?? config.durabilityMultiplier ?? config.durabilityEfficiency, DEFAULT_SHU.durabilityScalar),
-      pierceCount: (() => {
-        const val = toFinite(config.pierceCount ?? config.pierce ?? config.pierceBonus);
-        return val !== null && val >= 0 ? val : DEFAULT_SHU.pierceCount;
-      })()
-    };
-    Items.shuDefaults = { ...runtime.shuDefaults };
-    return { ...runtime.shuDefaults };
   }
 
   function locateWeaponHud(root = document) {
     if (!root || typeof root.querySelector !== "function") return null;
-    for (const selector of runtime.weaponHudSelectors) {
+    for (const selector of weaponHudSelectors) {
       const el = root.querySelector(selector);
       if (el) return el;
     }
@@ -275,30 +443,38 @@
 
   function setWeaponHudSelectors(selectors) {
     if (!Array.isArray(selectors)) return;
-    runtime.weaponHudSelectors = selectors.filter(sel => typeof sel === "string" && sel.trim().length > 0);
-    if (runtime.weaponHudSelectors.length === 0) {
-      runtime.weaponHudSelectors = [...DEFAULT_WEAPON_HUD_SELECTORS];
+    weaponHudSelectors = selectors
+      .map(sel => (typeof sel === "string" ? sel.trim() : ""))
+      .filter(Boolean);
+    if (weaponHudSelectors.length === 0) {
+      weaponHudSelectors = DEFAULT_WEAPON_HUD_SELECTORS.slice();
     }
-    runtime.weaponHudSelectors = runtime.weaponHudSelectors.map(sel => sel.trim());
+    runtime.weaponHudSelectors = weaponHudSelectors.slice();
+    Items.weaponHudSelectors = runtime.weaponHudSelectors.slice();
   }
 
-  function registerActiveWeapon(state, weapon) {
-    if (state && typeof state === "object" && weapon && typeof weapon === "object") {
-      rememberWeapon(state, weapon);
-      return;
+  function getActiveWeapon(state) {
+    const weapon = Items.getActiveItem();
+    if (weapon) return weapon;
+    if (state && typeof state === "object" && state.weapon && typeof state.weapon === "object") {
+      return state.weapon;
     }
-    if (state && typeof state === "object") {
-      forgetWeapon(state);
-      return;
-    }
-    runtime.activeWeapon = {
-      owner: null,
-      item: weapon && typeof weapon === "object" ? weapon : null
-    };
-    if (runtime.activeWeapon.item) runtime.lastWeapon = runtime.activeWeapon.item;
+    return null;
   }
 
-  Items.getActiveWeapon = detectActiveWeapon;
+  function isWeaponOut(state, weapon) {
+    if (!weapon || typeof weapon !== "object") return false;
+    if (Items.getActiveItem() === weapon) return true;
+    if (recordedShu && recordedShu.weapon === weapon) {
+      return !!recordedShu.weaponOut;
+    }
+    if (state && typeof state === "object" && state.weapon === weapon) {
+      return true;
+    }
+    return false;
+  }
+
+  Items.getActiveWeapon = getActiveWeapon;
   Items.isWeaponOut = isWeaponOut;
   Items.computeShuModifiers = computeShuModifiers;
   Items.applyShuDurabilityCost = applyShuDurabilityCost;
@@ -307,6 +483,62 @@
   Items.setShuDefaults = setShuDefaults;
   Items.locateWeaponHud = locateWeaponHud;
   Items.setWeaponHudSelectors = setWeaponHudSelectors;
-  Items.registerActiveWeapon = registerActiveWeapon;
-  Items.shuDefaults = { ...runtime.shuDefaults };
+  Items.shuDefaults = { ...shuDefaults };
+
+  const hx = globalObj.HXH = globalObj.HXH || {};
+  const previousOutgoing = typeof hx.applyOutgoingDamage === "function" ? hx.applyOutgoingDamage.bind(hx) : null;
+  const previousIncoming = typeof hx.applyIncomingDamage === "function" ? hx.applyIncomingDamage.bind(hx) : null;
+
+  function applyOutgoingDamageHook(src, limb, baseDamage) {
+    let result = Number.isFinite(baseDamage) ? baseDamage : 0;
+    if (previousOutgoing) {
+      try {
+        result = previousOutgoing(src, limb, result);
+      } catch (err) {
+        console.warn("[HXH] previous applyOutgoingDamage failed", err);
+      }
+    }
+    const weapon = Items.getActiveItem();
+    if (!ownerState || src !== ownerState) {
+      pendingAttack = null;
+      return result;
+    }
+    if (!weapon) {
+      pendingAttack = null;
+      return result;
+    }
+    const bonus = toNumber(weapon.dmg, 0);
+    const durabilityCost = applyShuDurabilityCost(1, ownerState, weapon);
+    const safeCost = Math.max(0, toNumber(durabilityCost, 1));
+    pendingAttack = { weapon, cost: safeCost > 0 ? safeCost : 1 };
+    return result + bonus;
+  }
+
+  function applyIncomingDamageHook(dst, limb, baseDamage) {
+    let result = Number.isFinite(baseDamage) ? baseDamage : 0;
+    if (previousIncoming) {
+      try {
+        result = previousIncoming(dst, limb, result);
+      } catch (err) {
+        console.warn("[HXH] previous applyIncomingDamage failed", err);
+      }
+    }
+    if (!pendingAttack || !ownerState) return result;
+    if (!dst || dst === ownerState) return result;
+    if (!markHit(pendingAttack, dst)) return result;
+    const weapon = pendingAttack.weapon;
+    if (!weapon || weapon.broken) {
+      pendingAttack = null;
+      return result;
+    }
+    const remaining = damageItem(weapon, pendingAttack.cost);
+    if (remaining <= 0) {
+      breakItem(weapon, "durability");
+      pendingAttack = null;
+    }
+    return result;
+  }
+
+  hx.applyOutgoingDamage = applyOutgoingDamageHook;
+  hx.applyIncomingDamage = applyIncomingDamageHook;
 })();


### PR DESCRIPTION
## Summary
- rebuild the Items module around the required item schema with slots/hotbar arrays and add/use/equip helpers
- hook player damage into durability consumption and break events while keeping Shu/HUD helpers available
- update the game hotbar break feedback to read the new inventory change payloads

## Testing
- node --check items-and-crafting.js
- node --check game.js
- node --check hud.js

------
https://chatgpt.com/codex/tasks/task_e_68d9c32d3f6c8330a0bd577604a514fa