### PR TITLE
Ensure vow restrictions apply to all AoE hits

### DIFF
--- a/nen-combat.js
+++ b/nen-combat.js
@@ -350,7 +350,8 @@ export function applyIncomingDamage(dst, limb, baseDamage) {
     }
   }
   const context = H.__lastOutgoingContext;
-  if (context && context.src === playerState && dst && dst !== playerState) {
+  const isPlayerOutgoing = context && context.src === playerState && dst && dst !== playerState;
+  if (isPlayerOutgoing) {
     if (typeof H.applyVowToIncoming === "function") {
       try {
         const vowRes = H.applyVowToIncoming({ target: dst, damage: result, context });
@@ -369,7 +370,20 @@ export function applyIncomingDamage(dst, limb, baseDamage) {
       }
     }
   }
-  H.__lastOutgoingContext = null;
+  if (isPlayerOutgoing) {
+    if (typeof setTimeout === "function") {
+      setTimeout(() => {
+        const hx = getHXH();
+        if (hx.__lastOutgoingContext === context) {
+          hx.__lastOutgoingContext = null;
+        }
+      }, 0);
+    } else if (H.__lastOutgoingContext === context) {
+      H.__lastOutgoingContext = null;
+    }
+  } else {
+    H.__lastOutgoingContext = null;
+  }
   console.log("[HXH] applyIncomingDamage", limb, baseDamage, "->", result);
   return result;
 }


### PR DESCRIPTION
## Summary
- track whether the current incoming damage originates from the player
- defer clearing the last outgoing context to allow vow checks on multi-target hits

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da79fae0808330bcc36321f4e566ad