### PR TITLE
Add grudge system and exorcism support

### DIFF
--- a/enemies.js
+++ b/enemies.js
@@ -21,6 +21,12 @@
     ranged: "caster"
   };
 
+  const CURSE_PROFILES = {
+    bruiser: { chance: 0.12, duration: 5200, dot: 4.5, slow: 0.08, maxStacks: 3 },
+    assassin: { chance: 0.18, duration: 6400, dot: 5.5, slow: 0.12, maxStacks: 4 },
+    caster: { chance: 0.22, duration: 7200, dot: 6, slow: 0.1, maxStacks: 4 }
+  };
+
   const intelState = {
     list: [],
     updatedAt: 0
@@ -164,6 +170,8 @@
     }
     enemy.nenArchetype = archetype;
     enemy.nenLiteracy = true;
+    const curseProfile = archetype ? CURSE_PROFILES[archetype] || null : null;
+    enemy.__curseProfile = curseProfile ? { ...curseProfile } : null;
     processed.add(enemy);
     if (archetype === "bruiser") {
       enemy.__nenTelegraph = {
@@ -421,6 +429,10 @@
     },
     getAuraIntel() {
       return intelState.list.slice();
+    },
+    getCurseProfile(enemy) {
+      if (!enemy) return null;
+      return enemy.__curseProfile || null;
     },
     onSpawnPlan(cb) {
       if (typeof cb !== "function") return () => {};


### PR DESCRIPTION
## Summary
- add HUD widget for the new grudge meter and exorcism action
- track damage to fill a grudge bar and curse killers with a slowing DoT on death
- let enemies inflict lingering curses that can be cleared with exorcism charms

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da899e778c8330b462bf377b76993a