### PR TITLE
Cancel pending runtime save when wiping data

### DIFF
--- a/game.js
+++ b/game.js
@@ -1484,14 +1484,18 @@
    }
 
    function wipeSave() {
-   try {
-      localStorage.removeItem(SAVE_KEYS.progress);
-      localStorage.removeItem(SAVE_KEYS.character);
-      localStorage.removeItem(SAVE_KEYS.runtime);
-      localStorage.removeItem(VOW_STORAGE_KEY);
-      lastRuntimeSnapshot = null;
-   } catch {}
-}
+      try {
+         localStorage.removeItem(SAVE_KEYS.progress);
+         localStorage.removeItem(SAVE_KEYS.character);
+         localStorage.removeItem(SAVE_KEYS.runtime);
+         localStorage.removeItem(VOW_STORAGE_KEY);
+         lastRuntimeSnapshot = null;
+      } catch {}
+      if (runtimeSaveTimer) {
+         clearTimeout(runtimeSaveTimer);
+         runtimeSaveTimer = null;
+      }
+   }
 
    function loadRuntimeState() {
       try {


### PR DESCRIPTION
## Summary
- clear any pending runtime save timer when wiping save data to prevent old state from being restored

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dab5d4d50c8330837e877ae8e78102