### PR TITLE
Add instancing pool and convert vegetation to instances

### DIFF
--- a/region-manager.js
+++ b/region-manager.js
@@ -323,6 +323,28 @@
     return lastCommand;
   }
 
+  function spawnInstances(type, transforms, options) {
+    if (!type) return [];
+    try {
+      const fn = window.HXH?.spawnInstances;
+      return typeof fn === "function" ? fn(type, transforms, options) || [] : [];
+    } catch (err) {
+      console.warn("[RegionManager] spawnInstances failed", err);
+      return [];
+    }
+  }
+
+  function despawnInstances(type, ids) {
+    if (!type) return 0;
+    try {
+      const fn = window.HXH?.despawnInstances;
+      return typeof fn === "function" ? fn(type, ids) || 0 : 0;
+    } catch (err) {
+      console.warn("[RegionManager] despawnInstances failed", err);
+      return 0;
+    }
+  }
+
   const API = {
     registerRegion,
     listRegions,
@@ -333,6 +355,8 @@
     onRegionChange,
     runCommand,
     getLastCommand,
+    spawnInstances,
+    despawnInstances,
     getLODConfig: id => buildRegionLodProfile(id || activeRegionId),
     getDefaultLODConfig: () => ({ version: DEFAULT_LOD_CONFIG.version, assets: clone(DEFAULT_LOD_CONFIG.assets) }),
     setTerrainRadius: (radius, opts) => window.WorldUtils?.setTerrainStreamingRadius?.(radius, opts),


### PR DESCRIPTION
## Summary
- add a reusable instance pool with thin-instance upgrades for high prop counts
- rebuild fallback tree scattering to use shared instanced meshes while keeping LOD proxies intact
- expose instance spawn/despawn helpers through the region manager for tooling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dae24649bc8330aa2318d418154708