### PR TITLE
Schedule eviction after unused asset finishes loading

### DIFF
--- a/region-manager.js
+++ b/region-manager.js
@@ -487,6 +487,9 @@
       state.promise = null;
       state.error = null;
       markAssetUsed(state);
+      if (state.refCount === 0 && state.warmCount === 0) {
+        scheduleEviction(state);
+      }
       return payload;
     }).catch((err) => {
       state.status = "error";


### PR DESCRIPTION
## Summary
- schedule an eviction when an asset load resolves but the asset remains unused

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb8f3b2c483309c33260f0abb8754