### PR TITLE
Fix wildcard escaping to preserve literal backslashes

### DIFF
--- a/game.js
+++ b/game.js
@@ -847,6 +847,7 @@
 
          for (const char of source) {
             if (escapeNext) {
+               regex += "\\\\";
                regex += specials.test(char) ? `\\${char}` : char;
                escapeNext = false;
                continue;


### PR DESCRIPTION
## Summary
- ensure wildcardToRegExp always emits a literal backslash when escaping characters so backslash matches are preserved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbbdfd08108330a550fb07d8b590e3