### PR TITLE
Fix wildcard escape handling

### DIFF
--- a/game.js
+++ b/game.js
@@ -1196,8 +1196,11 @@
 
          for (const char of source) {
             if (escapeNext) {
-               regex += "\\\\";
-               regex += specials.test(char) ? `\\${char}` : char;
+               if (char === "\\") {
+                  regex += "\\\\";
+               } else {
+                  regex += specials.test(char) ? `\\${char}` : char;
+               }
                escapeNext = false;
                continue;
             }


### PR DESCRIPTION
## Summary
- ensure escaped wildcards do not emit extra backslashes in generated regex

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc36906b08330bca3e7a1e91cd279