### PR TITLE
Fix canopy collider size computation

### DIFF
--- a/game.js
+++ b/game.js
@@ -4310,7 +4310,7 @@
             canopyMax.z = Math.max(canopyMax.z, box.maximumWorld.z);
          }
          if (Number.isFinite(canopyMin.x) && Number.isFinite(canopyMax.x)) {
-            const size = BABYLON.Vector3.Subtract(canopyMax, canopyMin);
+            const size = canopyMax.subtract(canopyMin);
             const width = Math.max(0.6, size.x * 1.02);
             const depth = Math.max(0.6, size.z * 1.02);
             const height = Math.max(0.5, size.y * 0.85);


### PR DESCRIPTION
## Summary
- replace the deprecated Vector3.Subtract call when computing canopy impostor size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc48258c08330aa8677220a25b4a2