### PR TITLE
Fix slow lane accumulator decrement

### DIFF
--- a/game.js
+++ b/game.js
@@ -1073,7 +1073,7 @@
             const stats = integratePhysicsStep(slowDt, "slow");
             slowSpent = nowMs() - slowStart;
             slowSteps = stats.processed;
-            physics.slowLaneAccumulator -= slowDt;
+            physics.slowLaneAccumulator = Math.max(0, physics.slowLaneAccumulator - physics.slowLaneInterval);
          }
       }
       physics.instrumentation.lastSlowCount = slowSteps;


### PR DESCRIPTION
## Summary
- ensure the slow-lane accumulator deducts the configured interval after a slow update so bodies respect the reduced cadence

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc9f332b083309c23c49063558ff2