### PR TITLE
Fix rig node map initialization order

### DIFF
--- a/game.js
+++ b/game.js
@@ -8113,13 +8113,13 @@
          });
       }
 
-      applyBasePose();
-      syncRigNodesToQuaternion(rigNodeMap);
-
       const rigNodeMap = {};
       PART_KEYS.forEach(key => {
          if (nodes[key]) rigNodeMap[key] = nodes[key];
       });
+
+      applyBasePose();
+      syncRigNodesToQuaternion(rigNodeMap);
 
       const rigAnimation = {
          binding: null,


### PR DESCRIPTION
## Summary
- define the humanoid rig node map before syncing quaternions to avoid a ReferenceError during setup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd533688e08330a073d1bcbabb9182