### PR TITLE
Apply rig editor results when returning to creator

### DIFF
--- a/game.js
+++ b/game.js
@@ -6346,6 +6346,21 @@
       return getCosmeticSelection();
    }
 
+   function setRigParameters(nextRig = undefined, { persist = true } = {}) {
+      const source = (typeof nextRig === "undefined") ? RIG : nextRig;
+      const normalized = ensureRig(source);
+      RIG = normalized;
+      if (persist && typeof localStorage !== "undefined") {
+         try {
+            localStorage.setItem(RIG_KEY, JSON.stringify(RIG));
+         } catch (err) {}
+      }
+      try {
+         window.CharacterCreator?.refresh?.();
+      } catch (err) {}
+      return deepClone(RIG);
+   }
+
    // ensure transforms exist and are numeric
    function ensureRig(rig) {
       const r = rig && typeof rig === "object" ? rig : {};
@@ -10488,6 +10503,7 @@
       setOutfit,
       setShoes,
       setAccessories,
+      setRig: setRigParameters,
       getSavedCosmeticLoadout,
       saveCosmeticLoadout,
       applyCosmeticLoadout,
@@ -10589,6 +10605,7 @@ try {
     setOutfit,
     setShoes,
     setAccessories,
+    setRig: setRigParameters,
   });
   // share rig definitions for the editor if available
   window.RigDefinitions = {

--- a/hud.js
+++ b/hud.js
@@ -3916,7 +3916,34 @@
       }
     })();
 
-    const onReturn = () => {
+    const onReturn = (result = {}) => {
+      const hx = window.HXH || {};
+      if (result && typeof result === "object") {
+        const { rig: nextRig, cosmetics: nextCosmetics } = result;
+        const rigType = typeof result.rigType === "string" ? result.rigType : null;
+        const wantsRigUpdate = nextRig != null || rigType;
+        if (wantsRigUpdate && typeof hx.setRig === "function") {
+          let payload = nextRig != null && typeof nextRig === "object" ? deepClone(nextRig) : {};
+          if (rigType && typeof payload === "object" && payload) {
+            payload = { ...payload, rigType };
+          }
+          try {
+            hx.setRig(payload);
+          } catch (err) {
+            console.warn("[Creator] Failed to apply rig from editor", err);
+          }
+        }
+        if (nextCosmetics && typeof hx.applyCosmeticLoadout === "function") {
+          try {
+            const applied = hx.applyCosmeticLoadout(deepClone(nextCosmetics), { persist: true });
+            if (applied && typeof applied === "object") {
+              state.selection = deepClone(applied);
+            }
+          } catch (err) {
+            console.warn("[Creator] Failed to apply cosmetics from editor", err);
+          }
+        }
+      }
       const dom = ensureDom();
       document.querySelectorAll(".screen").forEach(s => s.classList.remove("visible"));
       if (dom?.screen) {


### PR DESCRIPTION
## Summary
- update the creator's rig editor callback to apply returned rig and cosmetic changes before reopening the UI
- add an HXH.setRig helper that normalizes, persists, and exposes rig updates for the creator callback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddca4f79848330ad91f404d55cbfbb