### PR TITLE
Fix duplicate timeline span const

### DIFF
--- a/rig-editor.js
+++ b/rig-editor.js
@@ -2202,7 +2202,6 @@
       });
 
       const range = currentRange();
-      const total = Math.max(1, range.end - range.start);
 
       if (!jointNames.length){
         const empty = document.createElement("div");


### PR DESCRIPTION
## Summary
- remove the second `total` constant inside `drawTimeline` to avoid redeclaring the same name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddcf933c6c8330b5b24f28b652ca0b