### PR TITLE
Fix terrain material reuse check

### DIFF
--- a/game.js
+++ b/game.js
@@ -3271,7 +3271,12 @@
    }
 
    function ensureTerrainMaterial(scene) {
-      if (terrainTextureState.material && !terrainTextureState.material.isDisposed()) {
+      const existingMaterial = terrainTextureState.material;
+      const isExistingDisposed = typeof existingMaterial?.isDisposed === "function"
+         ? existingMaterial.isDisposed()
+         : existingMaterial?.isDisposed;
+
+      if (existingMaterial && !isExistingDisposed) {
          environment.terrainMaterial = terrainTextureState.material;
          if (!terrainTextureState.compressedReady && !terrainTextureState.compressedLoading) {
             maybeLoadCompressedTerrainAtlas(scene);


### PR DESCRIPTION
## Summary
- ensure the cached terrain material reuse logic handles materials whose `isDisposed` status is stored as a boolean property

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de815445fc8330bb6c851cd41a5d3f