### PR TITLE
feat: swap humanoid heads to rounded meshes

### DIFF
--- a/game.js
+++ b/game.js
@@ -8355,11 +8355,16 @@
       const headPivot = new BABYLON.TransformNode("head_pivot", scene);
       headPivot.parent = neck.pivot;
       nodes["head"] = headPivot;
-      const headM = BABYLON.MeshBuilder.CreateBox("head", {
-         width: s.head.w,
-         height: s.head.h,
-         depth: s.head.d
-      }, scene);
+      const headM = BABYLON.MeshBuilder.CreateSphere(
+         "head",
+         {
+            diameterX: s.head.w,
+            diameterY: s.head.h,
+            diameterZ: s.head.d,
+            segments: 32
+         },
+         scene
+      );
       headM.material = mat(color.scale(0.8));
       headM.parent = headPivot;
       headM.position.y = s.head.h * 0.5;
@@ -8375,7 +8380,7 @@
 
       const hairRoot = new BABYLON.TransformNode("hairRoot", scene);
       hairRoot.parent = headPivot;
-      hairRoot.position.y = s.head.h * 0.45;
+      hairRoot.position.y = s.head.h * 0.5;
 
       const accessoryRoot = new BABYLON.TransformNode("accessoryRoot", scene);
       accessoryRoot.parent = headPivot;

--- a/hud.js
+++ b/hud.js
@@ -3886,7 +3886,7 @@
     torsoLower: { w: 0.900, h: 0.450, d: 0.550 },
     torsoUpper: { w: 0.950, h: 0.710, d: 0.550 },
     neck: { w: 0.250, h: 0.250, d: 0.250 },
-    head: { w: 0.450, h: 0.500, d: 0.450 },
+    head: { w: 0.520, h: 0.520, d: 0.520 },
     arm: {
       upperW: 0.340, upperD: 0.340, upperLen: 0.750,
       foreW: 0.300, foreD: 0.270, foreLen: 0.700,
@@ -4746,7 +4746,7 @@
     const torsoLowerSize = segmentSize("torsoLower", { w: 0.9, h: 0.45, d: 0.55 });
     const torsoUpperSize = segmentSize("torsoUpper", { w: 0.95, h: 0.71, d: 0.55 });
     const neckSize = segmentSize("neck", { w: 0.25, h: 0.25, d: 0.25 });
-    const headSize = segmentSize("head", { w: 0.45, h: 0.5, d: 0.45 });
+    const headSize = segmentSize("head", { w: 0.52, h: 0.52, d: 0.52 });
 
     const armSource = rig?.arm || {};
     const armFallback = fallback?.arm || {};
@@ -4831,7 +4831,11 @@
     neck.pivot.position.y = 0.55;
     const headPivot = register("head", new BABYLON.TransformNode("creator-head_pivot", scene));
     headPivot.parent = neck.pivot;
-    const headMesh = BABYLON.MeshBuilder.CreateBox("creator-head", { width: headSize.w, height: headSize.h, depth: headSize.d }, scene);
+    const headMesh = BABYLON.MeshBuilder.CreateSphere(
+      "creator-head",
+      { diameterX: headSize.w, diameterY: headSize.h, diameterZ: headSize.d, segments: 32 },
+      scene
+    );
     headMesh.parent = headPivot;
     headMesh.position.y = headSize.h * 0.5;
     headMesh.material = makeBodyMat(0.8);
@@ -4845,7 +4849,7 @@
 
     const hairRoot = new BABYLON.TransformNode("creator-hair-root", scene);
     hairRoot.parent = headPivot;
-    hairRoot.position.y = headSize.h * 0.45;
+    hairRoot.position.y = headSize.h * 0.5;
 
     const accessoryRoot = new BABYLON.TransformNode("creator-accessory-root", scene);
     accessoryRoot.parent = headPivot;

--- a/rig-definitions.js
+++ b/rig-definitions.js
@@ -24,7 +24,7 @@
     torsoLower: { w: 0.9, h: 0.45, d: 0.55 },
     torsoUpper: { w: 0.95, h: 0.71, d: 0.55 },
     neck: { w: 0.25, h: 0.25, d: 0.25 },
-    head: { w: 0.45, h: 0.5, d: 0.45 },
+    head: { w: 0.52, h: 0.52, d: 0.52 },
     armL_upper: { w: 0.34, h: 0.75, d: 0.34 },
     armL_fore: { w: 0.3, h: 0.7, d: 0.27 },
     armL_hand: { w: 0.28, h: 0.25, d: 0.25 },


### PR DESCRIPTION
## Summary
- update humanoid rig segment defaults to use a rounder head profile
- build game head meshes with Babylon sphere geometry and keep hat/face anchors aligned
- mirror the rounded head in the character creator preview so cosmetics fit consistently

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e0101118e88330bd5972ca7f7aa65f