### PR TITLE
Fix creator preview grounding

### DIFF
--- a/game.js
+++ b/game.js
@@ -5647,13 +5647,26 @@
 
    function notifyFlowChange({ silent = false } = {}) {
       updateFlowHud();
-      if (flowListeners.size === 0) return;
+      const creatorHandler = window.CharacterCreator && typeof window.CharacterCreator.handleFlowSnapshot === "function"
+         ? window.CharacterCreator.handleFlowSnapshot
+         : null;
+      const hasListeners = flowListeners.size > 0;
+      if (!hasListeners && !creatorHandler) return;
       const snapshot = getFlowSnapshot();
-      for (const listener of flowListeners) {
+      if (hasListeners) {
+         for (const listener of flowListeners) {
+            try {
+               listener(snapshot);
+            } catch (err) {
+               console.error("Flow listener error", err);
+            }
+         }
+      }
+      if (creatorHandler) {
          try {
-            listener(snapshot);
+            creatorHandler(snapshot);
          } catch (err) {
-            console.error("Flow listener error", err);
+            console.warn("[Game] Failed to deliver flow snapshot to CharacterCreator", err);
          }
       }
    }


### PR DESCRIPTION
## Summary
- compute the creator preview rig's lowest point and offset the root so the feet sit on the floor
- rebuild or re-ground the preview when the rig signature changes or the active stance updates
- forward stance change snapshots from the game loop to the character creator preview

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e02464bd6c8330a45b7a0e2d5e554c