### PR TITLE
Fix ground offset accumulation

### DIFF
--- a/game.js
+++ b/game.js
@@ -10518,7 +10518,7 @@
             playerRoot.computeWorldMatrix(true);
             const sampleOffset = sampleRootGroundOffset(playerRoot);
             if (Number.isFinite(sampleOffset)) {
-               state.rootGroundOffsetTarget += sampleOffset;
+               state.rootGroundOffsetTarget = state.rootGroundOffset + sampleOffset;
             }
             state.groundSampleDirty = false;
             state.groundSampleCountdown = ROOT_GROUND_SAMPLE_INTERVAL;


### PR DESCRIPTION
## Summary
- avoid accumulating the sampled ground correction multiple times by deriving the target from the current offset

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e08df44834833082dbc62418faf0e8