### PR TITLE
Refactor rig editor startup for stability

### DIFF
--- a/game.js
+++ b/game.js
@@ -11399,7 +11399,21 @@ try {
       document.querySelectorAll(".screen").forEach(s => s.classList.remove("visible"));
       document.getElementById("screen--rig").classList.add("visible");
       window.MenuBG && window.MenuBG.stop();
-      window.RigEditor && window.RigEditor.boot();
+      const rigEditor = window.RigEditor;
+      if (rigEditor && typeof rigEditor.boot === "function") {
+         const bootResult = rigEditor.boot();
+         if (bootResult && typeof bootResult.then === "function") {
+            bootResult
+               .then((ok) => {
+                  if (ok === false) {
+                     console.warn("[Menu] Rig Editor boot did not complete successfully.");
+                  }
+               })
+               .catch((err) => {
+                  console.error("[Menu] Rig Editor boot promise rejected", err);
+               });
+         }
+      }
    });
 
    // first load -> decide whether to show Resume

--- a/index.html
+++ b/index.html
@@ -327,6 +327,7 @@
           </div>
           <!-- UPDATED help text -->
           <div class="rig-help">Left-drag: orbit • Right-drag: pan • Wheel: zoom</div>
+          <div id="rig-toast-root" class="rig-toast-root" aria-live="polite" aria-atomic="true"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- convert the rig editor boot process into an async phased startup with per-phase logging and null guards
- defer Babylon scene work until ready, add reusable toast notifications, and reset handlers safely
- update the menu and unlock flows to respect the boot promise and add a toast host element in the rig screen

## Testing
- not run (manual testing recommended)


------
https://chatgpt.com/codex/tasks/task_e_68e09f6723948330b28a5391d925919b