### PR TITLE
Add unified terrain mesh behind feature flag

### DIFF
--- a/region-manager.js
+++ b/region-manager.js
@@ -1333,6 +1333,12 @@
     ensureInteriorRuntime(region.id);
     window.Spawns?.useRegion?.(region);
     window.WorldUtils?.applyRegionVisuals?.(region);
+    const terrainApi = window.HXH?.Terrain || window.WorldUtils?.Terrain;
+    if (terrainApi && typeof terrainApi.setActiveRegion === "function") {
+      try { terrainApi.setActiveRegion(region); } catch (err) {
+        console.warn("[RegionManager] Failed to sync unified terrain region", err);
+      }
+    }
     const streamRadius = Number.isFinite(region.terrain?.streamRadius) ? region.terrain.streamRadius : null;
     window.WorldUtils?.setTerrainStreamingRadius?.(streamRadius, { mode: "base" });
     const lodProfile = buildRegionLodProfile(region.id);


### PR DESCRIPTION
## Summary
- add a feature-flagged Terrain module that builds an updatable heightfield mesh with sampling helpers to replace the legacy block floors when enabled
- propagate regional ground tinting to the unified mesh and expose the new API alongside existing WorldUtils helpers
- hook game terrain lifecycle, column streaming, and block destruction to the unified mesh while preserving the legacy fallback and syncing region activation

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1184019048330a971a79d3116f8a9