### PR TITLE
Add depth-based terrain vertex colors with configurable thresholds

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,15 @@
           </div>
           <label>Max Trees (performance cap) <input type="number" id="settings-max-trees" min="0" max="400" step="1" required />
           </label>
+          <fieldset class="terrain-thresholds">
+            <legend>Deformation Layers</legend>
+            <p class="small settings-note">Depth thresholds (world units) that switch the terrain from grass to dirt, clay, and bedrock.</p>
+            <div class="grid-3">
+              <label>Grass → Dirt <input type="number" id="settings-threshold-dirt" min="0" max="40" step="0.05" required /></label>
+              <label>Dirt → Clay <input type="number" id="settings-threshold-clay" min="0.05" max="60" step="0.05" required /></label>
+              <label>Clay → Bedrock <input type="number" id="settings-threshold-bedrock" min="0.1" max="80" step="0.05" required /></label>
+            </div>
+          </fieldset>
           <p class="small muted">Only cubes within the active radius are visible and collidable. Increase the radius for longer draw distances at the cost of performance.</p>
           <div class="row-right">
             <button type="button" id="settings-cancel" class="secondary">Cancel</button>

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,10 @@ legend{ padding:0 .4rem; color:var(--muted); }
 .grid-3{ display:grid; grid-template-columns:1fr 1fr 1fr; gap:.8rem; }
 .settings-form{ display:flex; flex-direction:column; gap:.6rem; }
 .settings-form .row-right{ margin-top:.6rem; }
+.terrain-thresholds{ margin-top:.2rem; }
+.terrain-thresholds .grid-3 label{ margin:0; }
+.terrain-thresholds input{ text-align:right; }
+.settings-note{ margin:.1rem 0 .5rem; }
 .row-right{ display:flex; gap:.6rem; justify-content:flex-end; }
 .small{ font-size:.9rem; color:var(--muted); }
 


### PR DESCRIPTION
## Summary
- track original unified-terrain vertex heights and recolor the mesh by deformation depth with smooth edge blending
- surface configurable depth thresholds in saved terrain settings and apply them to the terrain API
- extend the settings UI with controls for grass/dirt/clay/bedrock transition depths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e139624e80833083f0cd21482ae47a