### PR TITLE
Align creator cosmetics with anchor transforms

### DIFF
--- a/game.js
+++ b/game.js
@@ -12465,6 +12465,7 @@
       setOutfit,
       setShoes,
       setAccessories,
+      resolveCosmeticAnchor: (kind, id, segments) => resolveCosmeticAnchor(kind, id, segments || RIG),
       getCosmeticAnchor: (kind, id) => getCosmeticAnchorSnapshot(kind, id),
       adjustCosmeticAnchor: (kind, id, delta, opts) => adjustCosmeticAnchor(kind, id, delta || {}, opts || {}),
       resetCosmeticAnchor: (kind, id, opts) => resetCosmeticAnchor(kind, id, opts || {}),
@@ -12570,6 +12571,7 @@ try {
     setOutfit,
     setShoes,
     setAccessories,
+    resolveCosmeticAnchor: (kind, id, segments) => resolveCosmeticAnchor(kind, id, segments || RIG),
     setRig: setRigParameters,
   });
   // share rig definitions for the editor if available


### PR DESCRIPTION
## Summary
- add anchor transform nodes for the character creator preview head and reuse the game anchor resolver
- refresh face and hair anchors whenever preview cosmetics update to keep meshes aligned
- expose the resolveCosmeticAnchor helper through HXH for reuse in the creator

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3ff14ccc4833081eb778f0e383ae7