### PR TITLE
Enable QA panel override for production hosts

### DIFF
--- a/game.js
+++ b/game.js
@@ -10017,6 +10017,7 @@
       devHotkeyHandler = (event) => {
          if (event.code === "KeyD" && event.ctrlKey && event.shiftKey) {
             event.preventDefault();
+            hudApi?.setDevPanelOverride?.(true);
             hudApi?.toggleDevPanel?.();
          }
       };


### PR DESCRIPTION
## Summary
- add a persistent QA panel override flag that bypasses DEV_BUILD gating when enabled
- honor the override when creating and toggling the HUD dev panel and export helpers to control it
- ensure the Ctrl+Shift+D hotkey enables the override before toggling the panel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e413676cec833088f4ae24eb67b41b