### PR TITLE
Add terrain worker pool and voxel worker infrastructure

### DIFF
--- a/workers/terrain-worker.js
+++ b/workers/terrain-worker.js
@@ -1,0 +1,52 @@
+const ctx = self;
+
+function toUint32Array(source) {
+  if (!source) return null;
+  if (source instanceof Uint32Array) return source;
+  if (Array.isArray(source)) {
+    return Uint32Array.from(source.map((value) => value >>> 0));
+  }
+  if (ArrayBuffer.isView(source)) {
+    return new Uint32Array(source.buffer.slice(0));
+  }
+  if (source instanceof ArrayBuffer) {
+    return new Uint32Array(source.slice(0));
+  }
+  return null;
+}
+
+ctx.addEventListener('message', (event) => {
+  const data = event?.data || {};
+  const { jobId, payload } = data;
+  if (typeof jobId !== 'number') {
+    return;
+  }
+
+  try {
+    const { chunkVoxels, chunkSize = 0, scale = 1, atlasRects = [], flags = {} } = payload || {};
+    const voxels = toUint32Array(chunkVoxels) || new Uint32Array(0);
+
+    const occupancy = new Uint8Array(voxels.length);
+    let solidCount = 0;
+    for (let i = 0; i < voxels.length; i += 1) {
+      const solid = voxels[i] !== 0 ? 1 : 0;
+      occupancy[i] = solid;
+      solidCount += solid;
+    }
+
+    const result = {
+      chunkSize,
+      scale,
+      atlasRects,
+      flags,
+      voxelCount: voxels.length,
+      solidCount,
+      occupancy
+    };
+
+    ctx.postMessage({ jobId, result }, [occupancy.buffer]);
+  } catch (err) {
+    const message = err && typeof err === 'object' && 'message' in err ? err.message : String(err);
+    ctx.postMessage({ jobId, error: message });
+  }
+});


### PR DESCRIPTION
## Summary
- introduce a reusable terrain worker pool in `game.js` that manages worker lifecycle, metrics, and job dispatching
- schedule per-chunk voxel jobs when descriptors are applied while respecting worker enablement toggles
- add a dedicated `workers/terrain-worker.js` listener that processes voxel payloads and returns occupancy summaries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e583db47a08330adf42b2315bdf48d