### PR TITLE
Guard chunk worker results after terrain disposal

### DIFF
--- a/game.js
+++ b/game.js
@@ -4375,14 +4375,22 @@
       return mesh;
    }
 
-   function handleTerrainChunkJobResult(streaming, chunk, geometry) {
-      if (!streaming || !chunk || !geometry) return geometry;
-      const terrain = streaming.terrain;
-      if (!terrain || !scene) return geometry;
-      chunk.workerResult = geometry;
-      applyTerrainChunkGeometry(terrain, chunk, geometry);
-      return geometry;
-   }
+    function handleTerrainChunkJobResult(streaming, chunk, geometry) {
+       if (!streaming || !chunk || !geometry) return geometry;
+       const terrain = streaming.terrain;
+       if (!terrain || !scene) return geometry;
+       const currentTerrain = environment.terrain;
+       if (!currentTerrain || currentTerrain !== terrain || currentTerrain.streaming !== streaming) {
+          return geometry;
+       }
+       const root = terrain.root;
+       if (!root || root.isDisposed?.()) {
+          return geometry;
+       }
+       chunk.workerResult = geometry;
+       applyTerrainChunkGeometry(terrain, chunk, geometry);
+       return geometry;
+    }
 
    function queueChunkVoxelJob(streaming, chunk, terrain) {
       if (!streaming || !chunk || !terrain) return null;


### PR DESCRIPTION
## Summary
- add Babylon mesh management helpers to reuse chunk instances when worker jobs resolve
- apply worker-provided vertex/index buffers directly to meshes, assign terrain material, and parent to the terrain root
- cache worker geometry for regenerated chunks and keep mesh visibility in sync with streaming state
- guard chunk worker results to avoid applying geometry after terrain disposal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e58ecac5608330bff3af7874ff473b